### PR TITLE
Fix fonts on Windows

### DIFF
--- a/stylesheets/atom.less
+++ b/stylesheets/atom.less
@@ -1,6 +1,5 @@
 @import "ui-variables";
 
 #root-view {
-  font: caption;
   background-color: @app-background-color;
 }

--- a/stylesheets/ui-variables.less
+++ b/stylesheets/ui-variables.less
@@ -78,4 +78,4 @@
 
 // Other
 
-@font-family: 'Lucida Grande', Arial, sans-serif;
+@font-family: 'Lucida Grande', 'Segoe UI', sans-serif;


### PR DESCRIPTION
This PR is similar to atom/atom#1137, but for Windows. It appears that setting `font: caption` trumps some of the font settings and it wasn't clear that it was particularly useful so I nuked it
