### PR TITLE
Gives panes the app-background-color

### DIFF
--- a/stylesheets/panes.less
+++ b/stylesheets/panes.less
@@ -10,10 +10,10 @@
 
 .panes {
   .pane {
-    background-color: @app-background-color;
+    background-color: lighten(@app-background-color, 4%);
 
-    &:focus .item-views {
-      box-shadow: inset 0 0 7px #6aa5e9;
+    &:focus {
+      background-color: @app-background-color;
     }
   }
 


### PR DESCRIPTION
In the post-empty-panes world, there will always be a single root pane,
so the true background of workspace will never be visible.
