### PR TITLE
Add hover styles to close icons

### DIFF
--- a/stylesheets/tabs.less
+++ b/stylesheets/tabs.less
@@ -62,12 +62,21 @@
       z-index: 3;
       line-height: @tab-height;
       -webkit-transform: skewX(-@tab-skew);
+      color: @text-color;
+
+      &:hover {
+        color: inherit;
+      }
     }
     &.modified:not(:hover) .close-icon {
       top: @tab-height/2 - @modified-icon-width/2 + 1px;
       right: 14px;
       width: @modified-icon-width;
       height: @modified-icon-width;
+    }
+
+    &.modified:hover .close-icon:hover {
+      color: @text-color-highlight;
     }
 
     .title{
@@ -93,6 +102,7 @@
 
     .close-icon {
       line-height: @tab-height - 1px;
+      color: @text-color;
     }
 
     &, &:before {
@@ -111,7 +121,11 @@
   }
 
   .tab.active:hover .close-icon {
-    color: @text-color-highlight;
+    color: @text-color;
+
+    &:hover {
+      color: inherit;
+    }
   }
 
   .placeholder {


### PR DESCRIPTION
**Context**: Please refer to my recently closed pull request on atom/tabs: https://github.com/atom/tabs/pull/27

In response to atom/tabs changing the cursor of the close button on tabs, I've made some adjustments to this theme that will make closing tabs more intuitive.

Very bad quality gif:

![Screen Cast](https://f.cloud.github.com/assets/1610503/2360523/7cf68db2-a625-11e3-9d54-92d3e1d6132b.gif)
