### PR TITLE
fix some scrollbar issues

### DIFF
--- a/stylesheets/atom.less
+++ b/stylesheets/atom.less
@@ -10,11 +10,10 @@
 
 .scrollbars-visible-always {
   ::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
+    width: 12px;
+    height: 12px;
   }
 
-  ::-webkit-scrollbar-track,
   ::-webkit-scrollbar-corner {
     background: @scrollbar-background-color;
   }
@@ -22,6 +21,7 @@
   ::-webkit-scrollbar-thumb {
     background: @scrollbar-color;
     border-radius: 5px;
-    box-shadow: 0 0 1px black inset;
+    background-clip: padding-box;
+    border: 3px solid transparent;
   }
 }

--- a/stylesheets/editor.less
+++ b/stylesheets/editor.less
@@ -24,6 +24,10 @@
   -webkit-box-shadow: -2px 0 10px 2px #222;
 }
 
+.editor .vertical-scrollbar{
+  cursor: default;
+}
+
 @-webkit-keyframes highlight {
   from { background-color: rgba(100, 255, 100, 0.7); }
   to { background-color: null; }


### PR DESCRIPTION
In my opinion the scroll bars in atom look really weird, because they don't have any margin.

## Changes I made
* added some pseudo margin using background-clip and a transparent border.
* have set the cursor to default on '.editor .vertical-scrollbar' because I got the text select cursor otherwise while grabbing the scrollbar thumb.
* remove the background color from ::-webkit-scrollbar-track to remove the background for the scrollbar in the settings view, thus making it much more visible

## Screenshots

![screenshot from 2014-05-06 21 55 00](https://cloud.githubusercontent.com/assets/3409958/2895012/995735d8-d55a-11e3-8706-0063b695e25a.png)
![screenshot from 2014-05-06 21 55 22](https://cloud.githubusercontent.com/assets/3409958/2895014/9fff2c4c-d55a-11e3-919f-84881eb9ad85.png)


## Comparison
![c1](https://cloud.githubusercontent.com/assets/3409958/2895052/1c4b4830-d55b-11e3-860a-aef2fe8d0b9e.png)

