### PR TITLE
Use regular button text color for focus state

### DIFF
--- a/stylesheets/buttons.less
+++ b/stylesheets/buttons.less
@@ -6,6 +6,9 @@
   background-color: transparent;
   background-image: -webkit-linear-gradient(@color, darken(@color, 5%));
 
+  &:focus {
+    color: @text-color;
+  }
   &:hover {
     color: @text-color-highlight;
     background-image: -webkit-linear-gradient(@hover-color, darken(@hover-color, 5%));


### PR DESCRIPTION
This was really annoying me... Fixes https://github.com/atom/atom-dark-ui/issues/9
