### PR TITLE
Style selected items in the tree view according to their git-status

### DIFF
--- a/stylesheets/lists.less
+++ b/stylesheets/lists.less
@@ -26,6 +26,11 @@
     li.list-nested-item.status-@{status} > .list-item {
       color: @color;
     }
+
+    li:not(.list-nested-item).selected.status-@{status},
+    li.list-nested-item.selected.status-@{status} > .list-item {
+      color: @color;
+    }
   }
 
   .generate-list-item-status-color(@text-color-subtle, ignored);


### PR DESCRIPTION
This commit makes it less confusing when editing a document that has a modified status and is selected in the tree-view.

Before: the tree-view would always show a white font color even if the git status is modified (or renamed, removed, whatever).
![screen shot 2014-10-25 at 16 10 00](https://cloud.githubusercontent.com/assets/7480/4779982/c1fd63b8-5c50-11e4-8728-4c4785e54890.png)

After: The currently highlighted file in tree-view will use the git-status color
![screen shot 2014-10-25 at 16 10 29](https://cloud.githubusercontent.com/assets/7480/4779983/c4899a5c-5c50-11e4-9ead-07710a87f93f.png)

Please note that if the tree-view has _focus_, then the color would still be white.
One could say that it might be good to color it as well, but i found that the blue background + orange text color just looks ugly. And to me it doesn't really matter when the tree-view is in focus because i would mainly be interested in navigating my files. I could still see the git-status color indication while editing.

![screen shot 2014-10-25 at 16 10 43](https://cloud.githubusercontent.com/assets/7480/4779987/18cc8c00-5c51-11e4-9920-06aa8c1cfb23.png)
