### PR TITLE
Make resize handle a bit smaller

### DIFF
--- a/stylesheets/tree-view.less
+++ b/stylesheets/tree-view.less
@@ -10,6 +10,12 @@
   }
 }
 
+.tree-view-resizer {
+  .tree-view-resize-handle {
+    width: 8px;
+  }
+}
+
 .focusable-panel {
   opacity: 1;
   background: #303030;


### PR DESCRIPTION
Leaves more room for dragging the scrollbar. See https://github.com/atom/tree-view/issues/255
