### PR TITLE
Flip tree-view shadow when shown on right-hand side

### DIFF
--- a/stylesheets/tree-view.less
+++ b/stylesheets/tree-view.less
@@ -5,7 +5,7 @@
   background: @tree-view-background-color;
 
   .selected:before {
-  	background: #444;
+    background: #444;
     box-shadow: inset -3px 0 0 rgba(0,0,0, .05);
   }
 }
@@ -34,5 +34,12 @@
     .selected > .list-item > .name:before {
       color: #fff !important;
     }
+  }
+}
+
+[data-show-on-right-side=true] {
+  .tree-view .selected:before,
+  .focusable-panel {
+    box-shadow: inset 3px 0 0 rgba(0,0,0, .05);
   }
 }


### PR DESCRIPTION
I’m one of probably two people in the world who likes the tree-view on the right, but I noticed that the inset shadow doesn’t change sides with the setting. To me, the shadow here should always be on the side of the tree-view that borders the editor pane.

Currently:

![2015-01-08 at 10 41 am](https://cloud.githubusercontent.com/assets/296432/5661394/2ecfe6e8-9723-11e4-8e97-36e30aad3933.png)

![2015-01-08 at 10 43 am](https://cloud.githubusercontent.com/assets/296432/5661409/409012fe-9723-11e4-81b9-ff6fd71c513d.png)

This PR:

![2015-01-08 at 10 45 am](https://cloud.githubusercontent.com/assets/296432/5661425/718a8d58-9723-11e4-9da7-c63b208377de.png)

When selected: 

![2015-01-08 at 10 45 am](https://cloud.githubusercontent.com/assets/296432/5661426/77f189c6-9723-11e4-9de0-2a503c9a16af.png)

I’m not sure if it’s just me that this makes sense to or not. If that’s the case then feel free to close and ignore :grin: 