### PR TITLE
Allow easier clicking on tabs when in fullscreen mode

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -98,10 +98,12 @@
       color: @text-color-highlight;
     }
 
-    .title{
+    .title {
       position: relative;
       z-index: 1;
-      padding-right: 10px
+      margin-top: -@tab-top-padding;
+      padding-top: @tab-top-padding;
+      padding-right: 10px;
     }
   }
 


### PR DESCRIPTION
Fixes atom/atom#6715.

The theme has some empty space above tabs which makes it a little hard
to click on a tab, especially when in fullscreen mode. This change
increases the height of the tab (except for the ::before and ::after
parts) so that the empty space is clickable.