### PR TITLE
Prefix `animation` with `-webkit-` as required

### DIFF
--- a/styles/progress.less
+++ b/styles/progress.less
@@ -64,7 +64,7 @@ progress::-webkit-progress-value {
 
 progress[value] {
   background-image: @progress-shine-gradient;
-  animation: none;
+  -webkit-animation: none;
 }
 
 @-webkit-keyframes animate-stripes {


### PR DESCRIPTION
This properly disables the stripes animation for progress[value] and
decreases CPU usage when no animation needs to be done. animation is
not a valid attribute in Electron and is currently ignored.

This matches pull request https://github.com/atom/atom-light-ui/pull/26 in Atom's light UI theme.