### PR TITLE
Fix tab placeholder from jumping

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -144,10 +144,13 @@
 
   .placeholder {
     height: @tab-height + @tab-top-padding + @tab-bottom-border-height;
-    margin-left: -9px; // center between tabs
     pointer-events: none;
+    &:before {
+      margin-left: -9px; // center between tabs
+    }
     &:after {
       top: @tab-height + @tab-top-padding + @tab-bottom-border-height - 2px;
+      margin-left: -10px; // center between tabs
     }
   }
 }


### PR DESCRIPTION
### Description of the Change

This fixes the tab placeholder from jumping between tabs when dragging to a tab's center.

![atom-flappy-tab](https://user-images.githubusercontent.com/109225/31077356-23b4c51a-a776-11e7-8115-a22cdb358e95.gif)

### Benefits

No jumping

### Possible Drawbacks

None

### Applicable Issues

Fixes https://github.com/atom/atom-dark-ui/issues/72
